### PR TITLE
feat(constructor): allow empty constructor for in-memory default

### DIFF
--- a/src/TaggedKeyv.ts
+++ b/src/TaggedKeyv.ts
@@ -1,4 +1,4 @@
-import type Keyv from '@keyvhq/core';
+import Keyv from '@keyvhq/core';
 import { KeyvTagManager } from './KeyvTagManager';
 import type { TagManager } from './TagManager';
 
@@ -7,9 +7,9 @@ export class TaggedKeyv {
     private tagManager: TagManager;
     private locks: Map<string, Promise<void>> = new Map();
 
-    constructor(cache: Keyv, tagManager?: TagManager) {
-        this.cache = cache;
-        this.tagManager = tagManager || new KeyvTagManager(cache);
+    constructor(cache?: Keyv, tagManager?: TagManager) {
+        this.cache = cache || new Keyv();
+        this.tagManager = tagManager || new KeyvTagManager(this.cache);
     }
 
     /**

--- a/tests/TaggedKeyv.test.ts
+++ b/tests/TaggedKeyv.test.ts
@@ -24,6 +24,19 @@ describe('TaggedKeyv', () => {
             const instance = new TaggedKeyv(keyv, customTagManager);
             expect(instance).toBeInstanceOf(TaggedKeyv);
         });
+
+        it('should create with no parameters and function correctly', async () => {
+            const instance = new TaggedKeyv();
+            expect(instance).toBeInstanceOf(TaggedKeyv);
+
+            // Verify it works with the default in-memory store
+            await instance.set('foo', 'bar', { tags: ['test'] });
+            const value = await instance.get('foo');
+            expect(value).toBe('bar');
+
+            const results = await instance.getByTag('test');
+            expect(results).toEqual([['foo', 'bar']]);
+        });
     });
 
     describe('set - legacy API', () => {


### PR DESCRIPTION
The constructor now allows TaggedKeyv to be instantiated without any parameters, creating a default in-memory Keyv instance.

This aligns with the behavior of @keyvhq/core and improves ease of use for simple cases.

Closes #4

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Allow TaggedKeyv to be constructed with no arguments, defaulting to an in-memory Keyv store and a default KeyvTagManager.

### Why are these changes being made?

To enable easy in-memory usage without manual cache setup and ensure the default tag manager is wired to that in-memory cache. This aligns with common use cases and simplifies initialization.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cache initialization is now optional; if none is provided, a default in-memory store is used automatically.
  * Tag operations now consistently reference the active cache instance for improved reliability.
  * Updated constructor to accept an optional cache parameter, simplifying setup.

* **Tests**
  * Added coverage for no-argument construction and default in-memory behavior, including setting, retrieving, and tag-based retrieval of values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->