### PR TITLE
fix: implemented and tested getAllTags method

### DIFF
--- a/src/KeyvTagManager.ts
+++ b/src/KeyvTagManager.ts
@@ -172,4 +172,21 @@ export class KeyvTagManager implements TagManager {
             }
         }
     }
+
+    async getAllTags(): Promise<string[]> {
+        const tags = new Set<string>();
+        // Keyv's iterator method is used to iterate over all keys.
+        // This assumes the underlying Keyv store supports iteration.
+        // If not, a more specific implementation for the Keyv store would be needed.
+        const iterator = this.cache.iterator();
+        let entry = await iterator.next();
+        while (!entry.done) {
+            const [key] = entry.value;
+            if (key.startsWith(TAG_PREFIX)) {
+                tags.add(key.substring(TAG_PREFIX.length));
+            }
+            entry = await iterator.next();
+        }
+        return Array.from(tags);
+    }
 }

--- a/src/TagManager.ts
+++ b/src/TagManager.ts
@@ -46,4 +46,9 @@ export interface TagManager {
      * Compact/optimize tag storage (implementation-specific)
      */
     compact(tags?: string[]): Promise<void>;
+
+    /**
+     * Get all unique tags currently stored.
+     */
+    getAllTags(): Promise<string[]>;
 }

--- a/tests/KeyvTagManager.test.ts
+++ b/tests/KeyvTagManager.test.ts
@@ -236,6 +236,31 @@ describe('KeyvTagManager', () => {
         });
     });
 
+    describe('getAllTags', () => {
+        it('should return all unique tags', async () => {
+            await tagManager.setTagsForKey('user:123', ['users', 'active']);
+            await tagManager.setTagsForKey('product:abc', ['products', 'featured']);
+            await tagManager.setTagsForKey('order:xyz', ['orders']);
+
+            const allTags = await tagManager.getAllTags();
+            TestUtils.expectArraysEqualUnordered(allTags, ['users', 'active', 'products', 'featured', 'orders']);
+        });
+
+        it('should return an empty array if no tags exist', async () => {
+            const allTags = await tagManager.getAllTags();
+            expect(allTags).toEqual([]);
+        });
+
+        it('should return unique tags even with duplicates in storage', async () => {
+            await tagManager.addKeyToTag('key1', 'tagA');
+            await tagManager.addKeyToTag('key2', 'tagA');
+            await tagManager.addKeyToTag('key3', 'tagB');
+
+            const allTags = await tagManager.getAllTags();
+            TestUtils.expectArraysEqualUnordered(allTags, ['tagA', 'tagB']);
+        });
+    });
+
     describe('edge cases', () => {
         it('should handle malformed data gracefully', async () => {
             // Set invalid data directly


### PR DESCRIPTION
This commit re-introduces and implements the  method, which was previously missing from the  interface and
 implementation.

- Added  to  interface.
- Implemented  in  to retrieve all unique tags.
- Added comprehensive unit tests for  functionality.