### PR TITLE
docs: making ttl are milliseconds clearer

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ await cache.set('user:123', { name: 'John' });
 const user = await cache.get('user:123');
 
 // PLUS tag functionality
-await cache.set('user:123', { name: 'John' }, { 
-  ttl: 3600, 
-  tags: ['users', 'active'] 
+await cache.set('user:123', { name: 'John' }, {
+  ttl: 3600000, // 1 hour in milliseconds
+  tags: ['users', 'active']
 });
 
 // Invalidate all users at once
@@ -49,14 +49,16 @@ await cache.invalidateTag('users');
 
 ### Core Methods (Keyv Compatible)
 
+**Note:** TTL values are in **milliseconds** (e.g., `3600000` = 1 hour).
+
 ```typescript
 // Set a value (backward compatible)
 await cache.set(key: string, value: T, ttl?: number): Promise<void>
 
 // Set a value with tags (new API)
-await cache.set(key: string, value: T, options?: { 
-  ttl?: number, 
-  tags?: string[] 
+await cache.set(key: string, value: T, options?: {
+  ttl?: number, // TTL in milliseconds
+  tags?: string[]
 }): Promise<void>
 
 // Get a value
@@ -103,14 +105,14 @@ await cache.compactTags(tags?: string[]): Promise<void>
 
 ```typescript
 // Create sessions with tags
-await cache.set('session:user1:web', { userId: 1, device: 'web' }, { 
-  ttl: 3600, 
-  tags: ['user:1', 'device:web', 'sessions'] 
+await cache.set('session:user1:web', { userId: 1, device: 'web' }, {
+  ttl: 3600000, // 1 hour in milliseconds
+  tags: ['user:1', 'device:web', 'sessions']
 });
 
-await cache.set('session:user1:mobile', { userId: 1, device: 'mobile' }, { 
-  ttl: 3600, 
-  tags: ['user:1', 'device:mobile', 'sessions'] 
+await cache.set('session:user1:mobile', { userId: 1, device: 'mobile' }, {
+  ttl: 3600000, // 1 hour in milliseconds
+  tags: ['user:1', 'device:mobile', 'sessions']
 });
 
 // Invalidate all sessions for user 1
@@ -143,9 +145,9 @@ await cache.invalidateTag('clothing');
 // Warm cache with frequently accessed data
 const users = await database.getActiveUsers();
 for (const user of users) {
-  await cache.set(`user:${user.id}`, user, { 
-    ttl: 1800, 
-    tags: ['users', 'warmed', `role:${user.role}`] 
+  await cache.set(`user:${user.id}`, user, {
+    ttl: 1800000, // 30 minutes in milliseconds
+    tags: ['users', 'warmed', `role:${user.role}`]
   });
 }
 
@@ -158,9 +160,11 @@ await cache.invalidateTag('warmed');
 ```typescript
 // Set up some data
 await cache.set('user:123', { name: 'Alice', role: 'admin' }, {
+  ttl: 1800000, // 30 minutes
   tags: ['users', 'role:admin', 'status:active']
 });
 await cache.set('session:abc', { userId: 123 }, {
+  ttl: 3600000, // 1 hour
   tags: ['sessions', 'device:web']
 });
 
@@ -254,7 +258,7 @@ const cache = new TaggedKeyv(keyv);
 await cache.set('key', 'value', 3600);
 
 // Plus new functionality
-await cache.set('key', 'value', { ttl: 3600, tags: ['tag1'] });
+await cache.set('key', 'value', { ttl: 3600000, tags: ['tag1'] }); // 1 hour
 ```
 
 ## Community & Support

--- a/docs/documentation/api-reference.md
+++ b/docs/documentation/api-reference.md
@@ -20,7 +20,8 @@ new TaggedKeyv(cache?: Keyv, tagManager?: TagManager)
 #### `set`
 
 -   **Signature:** `set<T>(key: string, value: T, options?: { ttl?: number; tags?: string[] }): Promise<void>`
--   **Description:** Sets a value in the cache with an optional TTL and an array of tags.
+-   **Description:** Sets a value in the cache with an optional TTL (in milliseconds) and an array of tags.
+-   **Note:** TTL values are in milliseconds (e.g., `3600000` = 1 hour).
 
 #### `get`
 

--- a/docs/documentation/api.md
+++ b/docs/documentation/api.md
@@ -20,7 +20,8 @@ new TaggedKeyv(keyv: Keyv, tagManager?: TagManager)
 #### `set`
 
 -   **Signature:** `set<T>(key: string, value: T, options?: { ttl?: number; tags?: string[] }): Promise<void>`
--   **Description:** Sets a value in the cache with an optional TTL and an array of tags.
+-   **Description:** Sets a value in the cache with an optional TTL (in milliseconds) and an array of tags.
+-   **Note:** TTL values are in milliseconds (e.g., `3600000` = 1 hour).
 
 #### `get`
 

--- a/docs/documentation/index.md
+++ b/docs/documentation/index.md
@@ -31,7 +31,7 @@ const cache = new TaggedKeyv(keyv);
 
 // Set a value with tags
 await cache.set('user:123', { name: 'John' }, {
-  ttl: 3600,
+  ttl: 3600000, // 1 hour in milliseconds
   tags: ['users', 'active']
 });
 

--- a/docs/documentation/usage-examples.md
+++ b/docs/documentation/usage-examples.md
@@ -36,12 +36,12 @@ Manage multiple sessions for a single user and invalidate them all at once upon 
 ```typescript
 // Create sessions with tags
 await cache.set('session:user1:web', { userId: 1, device: 'web' }, {
-  ttl: 3600,
+  ttl: 3600000, // 1 hour in milliseconds
   tags: ['user:1', 'device:web', 'sessions']
 });
 
 await cache.set('session:user1:mobile', { userId: 1, device: 'mobile' }, {
-  ttl: 3600,
+  ttl: 3600000, // 1 hour in milliseconds
   tags: ['user:1', 'device:mobile', 'sessions']
 });
 

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -19,7 +19,7 @@ describe('Integration Tests', () => {
                 'session:user1:web',
                 { userId: 1, device: 'web' },
                 {
-                    ttl: 3600,
+                    ttl: 3600000, // 1 hour
                     tags: ['user:1', 'device:web', 'sessions'],
                 }
             );
@@ -28,7 +28,7 @@ describe('Integration Tests', () => {
                 'session:user1:mobile',
                 { userId: 1, device: 'mobile' },
                 {
-                    ttl: 3600,
+                    ttl: 3600000, // 1 hour
                     tags: ['user:1', 'device:mobile', 'sessions'],
                 }
             );
@@ -37,7 +37,7 @@ describe('Integration Tests', () => {
                 'session:user2:web',
                 { userId: 2, device: 'web' },
                 {
-                    ttl: 3600,
+                    ttl: 3600000, // 1 hour
                     tags: ['user:2', 'device:web', 'sessions'],
                 }
             );
@@ -98,7 +98,7 @@ describe('Integration Tests', () => {
             // Warm cache with user data
             for (const user of userData) {
                 await taggedKeyv.set(`user:${user.id}`, user, {
-                    ttl: 1800,
+                    ttl: 1800000, // 30 minutes
                     tags: ['users', `role:${user.role}`, 'warmed'],
                 });
             }
@@ -461,7 +461,7 @@ describe('Integration Tests', () => {
             await taggedKeyv.set('old:key', 'old:value', 1000, ['old']);
 
             // New style
-            await taggedKeyv.set('new:key', 'new:value', { ttl: 1000, tags: ['new'] });
+            await taggedKeyv.set('new:key', 'new:value', { ttl: 60000, tags: ['new'] }); // 1 minute
 
             // Both should work
             const oldValue = await taggedKeyv.get('old:key');


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Update documentation and tests to clearly use TTL values in milliseconds, replacing previous examples that used seconds, and add explicit notes about TTL units across API docs, usage examples, and tests.

### Why are these changes being made?

Clarify TTL unit semantics to avoid misconfigurations (TTL in milliseconds); ensure docs, usage examples, and tests consistently reflect the millisecond TTL convention.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Clarified that TTL values are in milliseconds across all docs and examples.
  - Updated sample TTLs (e.g., 3600 → 3,600,000) with notes like “1 hour in milliseconds.”
  - Adjusted Quick Start, API reference, usage examples, and migration guides accordingly.
  - No behavior or API signature changes.

- Tests
  - Updated TTL values in tests to milliseconds.
  - Added tests validating tagged entries retrieval and deep equality for complex objects.
  - Preserved existing interfaces; changes are to test data and coverage only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->